### PR TITLE
fix(axi_ram): Fix readmemh bug in `axi_ram.v`

### DIFF
--- a/rtl/axi_ram.v
+++ b/rtl/axi_ram.v
@@ -173,7 +173,7 @@ initial begin
             mem[j] = 0;
         end
     end
-    if(mem_init_file_int != "none") $readmemh(mem_init_file_int, mem, 0, 2**(ADDR_WIDTH-2)-1);
+    if(mem_init_file_int != "none") $readmemh(mem_init_file_int, mem, 0, 2**(VALID_ADDR_WIDTH)-1);
 end
 
 always @* begin


### PR DESCRIPTION
- `readmemh` fails for memories that are not 32bit width
- This bug was introduced by our changes to the axi_ram.v in commit
ef0ca9d0d02e3d0e226c0cb0e5a650b0692ab8eb
- New `readmemh` tries to read a file with the same dimensions as the
memory