### PR TITLE
Fixed not being able to copy file to mem in verilator

### DIFF
--- a/rtl/axi_ram.v
+++ b/rtl/axi_ram.v
@@ -143,7 +143,7 @@ reg s_axi_rlast_pipe_reg = 1'b0;
 reg s_axi_rvalid_pipe_reg = 1'b0;
 
 // (* RAM_STYLE="BLOCK" *)
-reg [DATA_WIDTH-1:0] mem[(2**VALID_ADDR_WIDTH)-1:0];
+reg [DATA_WIDTH-1:0] mem[0:(2**VALID_ADDR_WIDTH)-1];
 
 wire [VALID_ADDR_WIDTH-1:0] s_axi_awaddr_valid = s_axi_awaddr >> (ADDR_WIDTH - VALID_ADDR_WIDTH);
 wire [VALID_ADDR_WIDTH-1:0] s_axi_araddr_valid = s_axi_araddr >> (ADDR_WIDTH - VALID_ADDR_WIDTH);
@@ -173,7 +173,8 @@ initial begin
             mem[j] = 0;
         end
     end
-    if(mem_init_file_int != "none") $readmemh(mem_init_file_int, mem, 0, 2**(VALID_ADDR_WIDTH)-1);
+    if(mem_init_file_int != "none")
+      $readmemh(mem_init_file_int, mem);
 end
 
 always @* begin


### PR DESCRIPTION
This commit fixes not being able to copy the firmware file to the mem in verilator. Icarus simulator seem to work as it used to.