### PR TITLE
Add block names in axi_interconnect.v

### DIFF
--- a/rtl/axi_interconnect.v
+++ b/rtl/axi_interconnect.v
@@ -460,7 +460,7 @@ genvar n;
 
 // request generation
 generate
-for (n = 0; n < S_COUNT; n = n + 1) begin
+for (n = 0; n < S_COUNT; n = n + 1) begin: req_gen
     assign request[2*n]   = s_axi_awvalid[n];
     assign request[2*n+1] = s_axi_arvalid[n];
 end
@@ -468,7 +468,7 @@ endgenerate
 
 // acknowledge generation
 generate
-for (n = 0; n < S_COUNT; n = n + 1) begin
+for (n = 0; n < S_COUNT; n = n + 1) begin: ack_gen
     assign acknowledge[2*n]   = grant[2*n]   && s_axi_bvalid[n] && s_axi_bready[n];
     assign acknowledge[2*n+1] = grant[2*n+1] && s_axi_rvalid[n] && s_axi_rready[n] && s_axi_rlast[n];
 end


### PR DESCRIPTION
Quartus requires verilog block names.
```
Error (10644): Verilog HDL error at axi_interconnect.v(463): this block requires a name
Error (10644): Verilog HDL error at axi_interconnect.v(471): this block requires a name
```